### PR TITLE
Correct package name of unit tests in anymaps_base

### DIFF
--- a/anymaps-base/src/test/java/com/car2go/maps/model/RectGeofenceTest.java
+++ b/anymaps-base/src/test/java/com/car2go/maps/model/RectGeofenceTest.java
@@ -1,7 +1,4 @@
-package com.daimler.car2go;
-
-import com.car2go.maps.model.LatLng;
-import com.car2go.maps.model.RectGeofence;
+package com.car2go.maps.model;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
👋  The unit test in the `anymaps_base` module was located in the package `com.daimler.car2go`, but all classes are in the `com.car2go.maps` package. 

This PR moves the test class to the correct package.